### PR TITLE
strcpyの\0用にmap配列の大きさを広げる

### DIFF
--- a/Innocent_Heart.c
+++ b/Innocent_Heart.c
@@ -137,7 +137,7 @@ static struct item_status item[Teki_NUM];//アイテムの数=敵の数
 static struct boss_status boss;//ボス情報
 static struct boss_attack_anime boss_attack[Boss_Attack_NUM];//ボスの攻撃
 
-char map[MapHeight][MapWidth];
+char map[MapHeight][MapWidth+1];
 
 //
 //Program start

--- a/Innocent_Heart.c
+++ b/Innocent_Heart.c
@@ -35,7 +35,7 @@ void Game_Clear(void);//ゲームクリア後の処理
 
 #define WindowWidth 640//ウィンドウの大きさ
 #define WindowHeight 480
-#define MapWidth 101
+#define MapWidth 100
 #define MapHeight 16
 #define Tex_NUM 3//マップイメージ数
 #define Scene_NUM 14//シーンのイメージ数


### PR DESCRIPTION
```
strcpy(map[ 0],"CAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA");
```
ステージ読み込み時にstrcpyがコピーしようとする\0がmap配列からはみ出るため、一部の環境で落ちていた
MapWidthを変えるとステージ端のカメラ固定処理とかでバグるので、配列の大きさを変更することで対応